### PR TITLE
modified

### DIFF
--- a/config/score/experiments/baseline.yaml
+++ b/config/score/experiments/baseline.yaml
@@ -8,16 +8,26 @@ backend:
     n_neighbors_ta: 1
     smote_ratio: 0.05
     smote_neighbors: 5
+    k_ref_normalize: 0
     metric: cosine
   - tgt_class: asdit.backends.Knn
     n_neighbors_so: 4
     n_neighbors_ta: 1
     smote_ratio: 0.05
     smote_neighbors: 5
+    k_ref_normalize: 0
     metric: cosine
   - tgt_class: asdit.backends.Knn
     n_neighbors_so: 1
     n_neighbors_ta: 1
     smote_ratio: 0.2
     smote_neighbors: 2
+    k_ref_normalize: 0
+    metric: cosine
+  - tgt_class: asdit.backends.Knn
+    n_neighbors_so: 1
+    n_neighbors_ta: 1
+    smote_ratio: 0
+    smote_neighbors: 0
+    k_ref_normalize: 16
     metric: cosine


### PR DESCRIPTION
- Most modifications are minor and do not affect the behavior.
- Only the following change has a functional impact:
Changed indexing from `[0:self.n_neighbors_so]` to `[:, : self.n_neighbors_so]` in `calc_normalized_score()`
```
# before
      scores = np.sort(pairwise_distances(embed, ref_embed, metric=self.metric)/ref_norm_const, axis=1)[0:self.n_neighbors_so].mean(axis=1)
```
  

```
# after
        scores = np.sort(
            pairwise_distances(embed, ref_embed, metric="euclidean") / ref_norm_const,
            axis=1,
        )[:, : self.n_neighbors_so].mean(axis=1)
        # (N_input, N_ref) -> (N_input, self.n_neighbors_so) -> (N_input,)
```