### PR TITLE
Bugfix: Duplicate Metric Definition in Backend Configuration

### DIFF
--- a/config/score/experiments/default.yaml
+++ b/config/score/experiments/default.yaml
@@ -8,7 +8,6 @@ backend:
   - tgt_class: asdkit.backends.Kmeans
     n_clusters: 16
     metric: cosine
-    metric: cosine
   - tgt_class: asdkit.backends.Knn
     n_neighbors_so: 1
     n_neighbors_ta: 1


### PR DESCRIPTION
This pull request addresses a bug in [the backend configuration](https://github.com/TakuyaFujimura/dcase-asd-toolkit/blob/main/config/score/experiments/default.yaml) where the metric parameter is defined multiple times within a single backend entry.

Specifically, in the asdkit.backends.Kmeans backend configuration, the metric: cosine line appears twice:

```yaml
- tgt_class: asdkit.backends.Kmeans
    n_clusters: 16
    metric: cosine
    metric: cosine
```