### PR TITLE
removed pretrained_models from __init__.py

### DIFF
--- a/asdkit/frontends/__init__.py
+++ b/asdkit/frontends/__init__.py
@@ -4,5 +4,4 @@ from .base import BaseFrontend
 from .base_plmodel import BasePLFrontend
 from .discriminative_model import BasicDisPLModel
 from .featex_model import FeatExPLModel
-from .pretrained_feature import BEATsFrozenModel, EATFrozenModel
 from .subspaceloss_model import SubspaceLossPLModel

--- a/asdkit/frontends/pretrained_feature/__init__.py
+++ b/asdkit/frontends/pretrained_feature/__init__.py
@@ -1,2 +1,0 @@
-from .beats import BEATsFrozenModel
-from .eat import EATFrozenModel

--- a/config/extract/experiments/scratch/raw_beats.yaml
+++ b/config/extract/experiments/scratch/raw_beats.yaml
@@ -5,7 +5,7 @@ infer_ver: null
 
 
 scratch_frontend:
-  tgt_class: asdkit.frontends.BEATsFrozenModel
+  tgt_class: asdkit.frontends.pretrained_feature.beats.BEATsFrozenModel
   model_cfg:
     ckpt_path: "pretrained_models/beats/BEATs_iter3.pt"
 

--- a/config/extract/experiments/scratch/raw_eat.yaml
+++ b/config/extract/experiments/scratch/raw_eat.yaml
@@ -5,7 +5,7 @@ infer_ver: null
 
 
 scratch_frontend:
-  tgt_class: asdkit.frontends.EATFrozenModel
+  tgt_class: asdkit.frontends.pretrained_feature.eat.EATFrozenModel
   model_cfg:
     ckpt_path: "pretrained_models/eat/EAT-base_epoch10_pt.pt"
     sec: ${dcase} # Zero pad to ${dcase} seconds


### PR DESCRIPTION
Before this fix, fairseq installation was required even when we don't use EAT (due to __init__.py)