### PR TITLE
Propose handling for DCASE2020: avoid domain-related metric table

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ ASDKit automatically computes the official evaluation scores according to the re
 |---------------|-------------|
 | s_auc / s_pauc | AUC / pAUC computed using normal and anomalous sounds in the source domain. |
 | t_auc / t_pauc | AUC / pAUC computed using normal and anomalous sounds in the target domain. |
-| mix_auc / pauc | AUC / pAUC computed using normal and anomalous sounds from both the source and target domains. |
+| mix_auc / mix_pauc | AUC / pAUC computed using normal and anomalous sounds from both the source and target domains. |
 | smix_auc       | AUC computed using normal and anomalous sounds in the source domain and anomalous sounds in the target domain. |
 | tmix_auc       | AUC computed using normal and anomalous sounds in the target domain and anomalous sounds in the source domain. |
 | official20-24  | Official evaluation score for DCASE 2020-2024 Challenge Task2. These are computed combining the above metrics. |

--- a/asdkit/bin/table.py
+++ b/asdkit/bin/table.py
@@ -33,8 +33,8 @@ def get_table_df(
     machine_list = MACHINE_DICT[f"{dcase}-{split}"]
     if dcase in ["dcase2020"]:
         # does NOT have a concept of domains
-        if(metric in ["t_auc", "mix_auc"]):
-            return
+        if metric in ["t_auc", "t_pauc", "smix_auc", "tmix_auc", "mix_auc", "mix_pauc"]:
+            return None
         metric = f"{split}_{metric}"
     elif dcase in ["dcase2021", "dcase2022"]:
         metric = f"{split}_{metric}"
@@ -46,6 +46,12 @@ def get_table_df(
     # Loop of machines
     for i, m in enumerate(machine_list):
         evaluate_df = pd.read_csv(output_dir / m / "test_evaluate.csv")
+        if metric not in evaluate_df:
+            logger.warning(
+                f"Metric {metric} not found in {output_dir / m / 'test_evaluate.csv'}. This metric will be skipped."
+            )
+            return None
+
         # check backend
         if i == 0:
             backend_array = evaluate_df.backend.values

--- a/asdkit/bin/table.py
+++ b/asdkit/bin/table.py
@@ -31,7 +31,12 @@ def get_table_df(
     # init
     evaluate_df_list = []
     machine_list = MACHINE_DICT[f"{dcase}-{split}"]
-    if dcase in ["dcase2020", "dcase2021", "dcase2022"]:
+    if dcase in ["dcase2020"]:
+        # does NOT have a concept of domains
+        if(metric in ["t_auc", "mix_auc"]):
+            return
+        metric = f"{split}_{metric}"
+    elif dcase in ["dcase2021", "dcase2022"]:
         metric = f"{split}_{metric}"
     elif dcase in ["dcase2023", "dcase2024"]:
         metric = f"0_{metric}"


### PR DESCRIPTION
# Description
DCASE2020 does not use the concept of domains, unlike later years of the challenge.
Currently, attempting to make a table of the metric string using a domain-based prefix (e.g., split_metric) for DCASE2020 results in either a meaningless metric name or a potential error.

This PR modifies the metric handling logic to avoid unnecessary making a table for DCASE2020, and skips unsupported metrics like t_auc or mix_auc, which are not relevant in the 2020 dataset.

By doing this, we avoid misleading error messages or logs that may confuse users into thinking the toolkit has bugs, especially when using DCASE2020.

# Changes
```Python
if dcase in ["dcase2020"]:
    # does NOT have a concept of domains
    if(metric in ["t_auc", "mix_auc"]):
        return
    metric = f"{split}_{metric}"
elif dcase in ["dcase2021", "dcase2022"]:
    metric = f"{split}_{metric}"
```

